### PR TITLE
Fixing the updating phase in the react component lifecycle

### DIFF
--- a/basic-react-components/6.7.md
+++ b/basic-react-components/6.7.md
@@ -91,9 +91,10 @@ Below I show a table for each category and the containing lifecycle methods.
 <ol>
 <li><code>componentWillReceiveProps()</code></li>
 <li><code>shouldComponentUpdate()</code></li>
+<li><code>componentWillUpdate()</code></li>
 <li><code>render()</code></li>
 <li>Children Life cycle methods</li>
-<li><code>componentWillUpdate()</code></li>
+<li><code>componentDidUpdate()</code></li>
 </ol>
 * Unmount Phase follows this order:
 <ol>


### PR DESCRIPTION
There is an issue on section 6.7 where the update lifecycle is wrong, it says:

```javascript
Updating Phase follows this order:
componentWillReceiveProps()
shouldComponentUpdate()
render()
Children Life cycle methods
componentWillUpdate()
```

But it should be:

```javascript
Updating Phase follows this order:
componentWillReceiveProps()
shouldComponentUpdate()
componentWillUpdate()
render()
Children Life cycle methods
componentDidUpdate()
```